### PR TITLE
unpack magnetic field at install time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Set the project name
-project(MagFieldMap VERSION 2.1.0
+project(MagFieldMap VERSION 0.1.0
                     DESCRIPTION "Repository for LDMX magnetic field maps."
 )
 
@@ -14,14 +14,9 @@ file(GLOB fieldmap_files *.tar.gz)
 
 # Check if the fieldmap has already been extracted.  If not, extract and install
 # the fieldmaps.
+install(CODE "execute_process(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/data/fieldmap)")
 foreach(fieldmap_path ${fieldmap_files})
-    get_filename_component(fieldmap_file ${fieldmap_path} NAME)
-    string(REPLACE ".tar.gz" "" fieldmap_file_raw ${fieldmap_file})
-    if (NOT EXISTS ${CMAKE_INSTALL_PREFIX}/data/fieldmap/${fieldmap_file_raw})
-        configure_file(${fieldmap_path} ${CMAKE_INSTALL_PREFIX}/data/fieldmap/${fieldmap_file} COPYONLY)
-        execute_process(COMMAND tar -zxvf ${fieldmap_file}
-                        WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/data/fieldmap
-        )
-        file(REMOVE ${CMAKE_INSTALL_PREFIX}/data/fieldmap/${fieldmap_file})
-    endif()
+  get_filename_component(fieldmap_file ${fieldmap_path} NAME)
+  install(CODE "message(STATUS \"unpacking ${fieldmap_file}\")")
+  install(CODE "execute_process(COMMAND tar -zxf ${fieldmap_path} WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/data/fieldmap)")
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Set the project name
-project(MagFieldMap VERSION 0.1.0
+project(MagFieldMap VERSION 0.2.0
                     DESCRIPTION "Repository for LDMX magnetic field maps."
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,8 @@ project(MagFieldMap VERSION 0.1.0
 
 message(STATUS "Installing all field map files.")
 
-# Retrieve all of the fieldmap files
+# retrieve list of the fieldmap files
 file(GLOB fieldmap_files *.tar.gz)
-
-# Check if the fieldmap has already been extracted.  If not, extract and install
-# the fieldmaps.
-install(CODE "execute_process(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/data/fieldmap)")
-foreach(fieldmap_path ${fieldmap_files})
-  get_filename_component(fieldmap_file ${fieldmap_path} NAME)
-  install(CODE "message(STATUS \"unpacking ${fieldmap_file}\")")
-  install(CODE "execute_process(COMMAND tar -zxf ${fieldmap_path} WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/data/fieldmap)")
-endforeach()
+# pass this information to the install script
+configure_file(install.cmake.in ${PROJECT_BINARY_DIR}/install.cmake @ONLY)
+install(SCRIPT ${PROJECT_BINARY_DIR}/install.cmake)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # MagFieldMap
 Magnetic field maps for LDMX detectors
+
+### BmapCorrected3D_13k_unfolded_scaled_1.15384615385.dat.tar.gz
+This fieldmap was taken from measurements of the dipole magnet used within HPS
+and then scaled to match the specifications of the dipole magnet expected to be
+used by LDMX.

--- a/install.cmake.in
+++ b/install.cmake.in
@@ -1,0 +1,38 @@
+# install magnetic fieldmaps only if the original tar-ball changes
+#
+# Assumptions
+#  - The magnetic fieldmaps are *.tar.gz files compressing a single file with the same name
+#    This assumption is necessary so that we can check for the existence of the unpacked
+#    file without having to inspect the contents of the tar-ball (only its file name).
+#
+# The fieldmaps are unpacked into the <install-path>/data/fieldmap directory and a timestamp
+# for when they were last installed is created within ${CMAKE_CURRENT_BINARY_DIRECTORY}/MagFieldMap
+# If the installed filed exists, this timestamp file exists and is newer than the original tar-ball, the unpacking
+# operation is not performed.
+# This logic allows for the tar-ball to only be unpacked when it is necessary (the tar-ball changes
+# due to e.g. a re-pull or the install hasn't happened yet).
+
+# retrieve list of the fieldmap files
+set(fieldmap_files "@fieldmap_files@")
+
+# define directory in which the files will be installed
+set(magfield_map_install $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/data/fieldmap)
+
+# make sure install location exists
+execute_process(COMMAND mkdir -p ${magfield_map_install})
+foreach(fieldmap_path ${fieldmap_files})
+  get_filename_component(fieldmap_file ${fieldmap_path} NAME)
+  string(REPLACE ".tar.gz" "" fieldmap_filename ${fieldmap_file})
+  set(fieldmap_install ${magfield_map_install}/${fieldmap_filename})
+  set(install_timestamp ${CMAKE_CURRENT_BINARY_DIR}/MagFieldMap/${fieldmap_filename}.stamp)
+  if (EXISTS ${fieldmap_install} AND EXISTS ${install_timestamp} AND ${install_timestamp} IS_NEWER_THAN ${fieldmap_path})
+    message(STATUS "Up-to-date: ${fieldmap_install}")
+  else()
+    message(STATUS "Installing: ${fieldmap_install}")
+    execute_process(
+      COMMAND tar -zxf ${fieldmap_path}
+      COMMAND touch ${install_timestamp}
+      WORKING_DIRECTORY ${magfield_map_install}
+    )
+  endif()
+endforeach()


### PR DESCRIPTION
This helps avoid writing to the install location until the user asks for an install. Unfortunately, this CMake will _always_ unpack the tar ball even if the tar-ball didn't change and the unpacked file(s) already exist.